### PR TITLE
Revert "remove GA callout in header for testing purposes"

### DIFF
--- a/header.php
+++ b/header.php
@@ -36,6 +36,22 @@
 	<meta name="msapplication-TileImage" content="<?php echo get_stylesheet_directory_uri().'/assets/images/favicon/favicon-144.png' ?>">
 	<script src="https://kit.fontawesome.com/79e986c029.js" crossorigin="anonymous"></script>
 
+	<?php
+	//Google Analytics
+	if ( !empty(get_theme_mod('google_analytics_code')) ){
+		$googleAnalytics = get_theme_mod('google_analytics_code'); ?>
+
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo $googleAnalytics ?>"></script>
+		<script>
+		  window.dataLayer = window.dataLayer || [];
+		  function gtag(){dataLayer.push(arguments);}
+		  gtag('js', new Date());
+
+		  gtag('config', '<?php echo $googleAnalytics ?>');
+		</script>
+	<?php } ?>
+
 </head>
 
 <body <?php body_class(); ?>>


### PR DESCRIPTION
Reverts ufclas/UF-CLAS-DEPT#250 - Want to see it I can use GTM only to add Google Analytics to the site, enabling us to set the cookie domain in GTM instead of relying on sitekit, which does it at the ufl.edu level